### PR TITLE
Fix Request Update Presence feature

### DIFF
--- a/Sources/DiscordGateway/BotGatewayManager.swift
+++ b/Sources/DiscordGateway/BotGatewayManager.swift
@@ -293,11 +293,11 @@ public actor BotGatewayManager: GatewayManager {
     
     /// https://discord.com/developers/docs/topics/gateway-events#update-presence
     public func updatePresence(payload: Gateway.Identify.Presence) {
-        /// This took a lot of time to figure out, not sure why it needs opcode `9` (works with `10` too?!).
+        /// This took a lot of time to figure out, not sure why it needs opcode `1`.
         self.send(payload: .init(
             opcode: .presenceUpdate,
             data: .requestPresenceUpdate(payload)
-        ), opcode: 9)
+        ), opcode: 1)
     }
     
     /// https://discord.com/developers/docs/topics/gateway-events#update-voice-state

--- a/Sources/DiscordModels/Types/Gateway.swift
+++ b/Sources/DiscordModels/Types/Gateway.swift
@@ -477,6 +477,18 @@ public struct Gateway: Sendable, Codable {
                 self.status = status
                 self.afk = afk
             }
+
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                if let since {
+                    try container.encode(since, forKey: .since)
+                } else {
+                    try container.encodeNil(forKey: .since)
+                }
+                try container.encode(self.activities, forKey: .activities)
+                try container.encode(self.status, forKey: .status)
+                try container.encode(self.afk, forKey: .afk)
+            }
         }
         
         public var token: Secret


### PR DESCRIPTION
This PR adress issue with broken presence update request feature. 
Seems like Discord has a bug: `since` property in the payload must be present explicitly, so we need to encode it manually to `null` if it not present. 
Also, WS opcode type changed from 9 (ping) to 1 (text) to fix communication issue.