### PR TITLE
Disable nightly main CI because unrelated failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,29 +8,29 @@ on:
 
 jobs:
   main-tests:
-    uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
+    uses: mahdibm/ci/.github/workflows/run-unit-tests.yml@main
     with:
       with_coverage: true
       with_tsan: true
       with_public_api_check: true
-      with_gh_codeql: false # Temporary, because it's broken
+      with_nightly_main_swift: false
       coverage_ignores: '/Tests/|/Plugins/|/Sources/CZlib/'
       test_filter: '^DiscordBMTests'
   macro-tests:
-    uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
+    uses: mahdibm/ci/.github/workflows/run-unit-tests.yml@main
     with:
       with_coverage: true
       with_tsan: true
       with_public_api_check: true
-      with_gh_codeql: false # Temporary, because it's broken
+      with_nightly_main_swift: false
       coverage_ignores: '/Tests/|/Plugins/|/Sources/CZlib/'
       test_filter: '^MacroTests'
   websocket-tests:
-    uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
+    uses: mahdibm/ci/.github/workflows/run-unit-tests.yml@main
     with:
       with_coverage: true
       with_tsan: false
       with_public_api_check: false
-      with_gh_codeql: false # Temporary, because it's broken
+      with_nightly_main_swift: false
       coverage_ignores: '/Tests/|/Plugins/|/Sources/CZlib/'
       test_filter: '^WebSocketTests'


### PR DESCRIPTION
<!-- Thanks in advance for the PR! -->
<!-- Please make sure you've followed DiscordBM's contributing guidelines. -->
<!-- Describe your changes clearly and use examples if possible. -->

> Passing the `linux-integration` tests is not required for PRs because of token/access problems.
