### PR TITLE
Allow custom ConnectionProperties for identifyPayload

### DIFF
--- a/Sources/DiscordModels/Types/Gateway.swift
+++ b/Sources/DiscordModels/Types/Gateway.swift
@@ -474,7 +474,7 @@ public struct Gateway: Sendable, Codable {
             public var device: String
 
             public init(
-                os: String = Self.defaultOS(),
+                os: String = Self.__defaultOS,
                 browser: String = "DiscordBM",
                 device: String = "DiscordBM"
             ) {
@@ -483,8 +483,7 @@ public struct Gateway: Sendable, Codable {
                 self.device = device
             }
 
-            @usableFromInline
-            static func defaultOS() -> String {
+            public static var __defaultOS: String {
                 #if os(macOS)
                     return "macOS"
                 #elseif os(Linux)

--- a/Sources/DiscordModels/Types/Gateway.swift
+++ b/Sources/DiscordModels/Types/Gateway.swift
@@ -473,7 +473,17 @@ public struct Gateway: Sendable, Codable {
             public var browser: String
             public var device: String
 
-            public init(os: String = {
+            public init(
+                os: String? = nil,
+                browser: String = "DiscordBM",
+                device: String = "DiscordBM"
+            ) {
+                self.os = os ?? ConnectionProperties.defaultOS()
+                self.browser = browser
+                self.device = device
+            }
+
+            private static func defaultOS() -> String {
                 #if os(macOS)
                     return "macOS"
                 #elseif os(Linux)
@@ -505,10 +515,6 @@ public struct Gateway: Sendable, Codable {
                 #else
                     return "Unknown"
                 #endif
-            }(), browser: String = "DiscordBM", device: String = "DiscordBM") {
-                self.os = os
-                self.browser = browser
-                self.device = device
             }
         }
         

--- a/Sources/DiscordModels/Types/Gateway.swift
+++ b/Sources/DiscordModels/Types/Gateway.swift
@@ -474,16 +474,17 @@ public struct Gateway: Sendable, Codable {
             public var device: String
 
             public init(
-                os: String? = nil,
+                os: String = Self.defaultOS(),
                 browser: String = "DiscordBM",
                 device: String = "DiscordBM"
             ) {
-                self.os = os ?? ConnectionProperties.defaultOS()
+                self.os = os
                 self.browser = browser
                 self.device = device
             }
 
-            private static func defaultOS() -> String {
+            @usableFromInline
+            static func defaultOS() -> String {
                 #if os(macOS)
                     return "macOS"
                 #elseif os(Linux)

--- a/Sources/DiscordModels/Types/Gateway.swift
+++ b/Sources/DiscordModels/Types/Gateway.swift
@@ -469,41 +469,47 @@ public struct Gateway: Sendable, Codable {
         
         /// https://discord.com/developers/docs/topics/gateway-events#identify-identify-connection-properties
         public struct ConnectionProperties: Sendable, Codable {
-            public var os: String = {
-#if os(macOS)
-                return "macOS"
-#elseif os(Linux)
-                return "Linux"
-#elseif os(iOS)
-                return "iOS"
-#elseif os(watchOS)
-                return "watchOS"
-#elseif os(tvOS)
-                return "tvOS"
-#elseif os(Windows)
-                return "Windows"
-#elseif canImport(Musl)
-                return "Musl"
-#elseif os(FreeBSD)
-                return "FreeBSD"
-#elseif os(OpenBSD)
-                return "OpenBSD"
-#elseif os(Android)
-                return "Android"
-#elseif os(PS4)
-                return "PS4"
-#elseif os(Cygwin)
-                return "Cygwin"
-#elseif os(Haiku)
-                return "Haiku"
-#elseif os(WASI)
-                return "WASI"
-#else
-                return "Unknown"
-#endif
-            }()
-            public var browser = "DiscordBM"
-            public var device = "DiscordBM"
+            public var os: String
+            public var browser: String
+            public var device: String
+
+            public init(os: String = {
+                #if os(macOS)
+                    return "macOS"
+                #elseif os(Linux)
+                    return "Linux"
+                #elseif os(iOS)
+                    return "iOS"
+                #elseif os(watchOS)
+                    return "watchOS"
+                #elseif os(tvOS)
+                    return "tvOS"
+                #elseif os(Windows)
+                    return "Windows"
+                #elseif canImport(Musl)
+                    return "Musl"
+                #elseif os(FreeBSD)
+                    return "FreeBSD"
+                #elseif os(OpenBSD)
+                    return "OpenBSD"
+                #elseif os(Android)
+                    return "Android"
+                #elseif os(PS4)
+                    return "PS4"
+                #elseif os(Cygwin)
+                    return "Cygwin"
+                #elseif os(Haiku)
+                    return "Haiku"
+                #elseif os(WASI)
+                    return "WASI"
+                #else
+                    return "Unknown"
+                #endif
+            }(), browser: String = "DiscordBM", device: String = "DiscordBM") {
+                self.os = os
+                self.browser = browser
+                self.device = device
+            }
         }
         
         /// https://discord.com/developers/docs/topics/gateway-events#update-presence-gateway-presence-update-structure
@@ -546,16 +552,18 @@ public struct Gateway: Sendable, Codable {
         public var presence: Presence?
         public var intents: IntBitField<Intent>
         
-        public init(token: Secret, large_threshold: Int? = nil, shard: IntPair? = nil, presence: Presence? = nil, intents: [Intent]) {
+        public init(token: Secret, properties: ConnectionProperties = ConnectionProperties(), large_threshold: Int? = nil, shard: IntPair? = nil, presence: Presence? = nil, intents: [Intent]) {
             self.token = token
+            self.properties = properties
             self.large_threshold = large_threshold
             self.shard = shard
             self.presence = presence
             self.intents = .init(intents)
         }
         
-        public init(token: String, large_threshold: Int? = nil, shard: IntPair? = nil, presence: Presence? = nil, intents: [Intent]) {
+        public init(token: String, properties: ConnectionProperties = ConnectionProperties(), large_threshold: Int? = nil, shard: IntPair? = nil, presence: Presence? = nil, intents: [Intent]) {
             self.token = Secret(token)
+            self.properties = properties
             self.large_threshold = large_threshold
             self.shard = shard
             self.presence = presence


### PR DESCRIPTION
This PR allows properties of identifyPayload to be modified and passed through when making an identifyPayload, by adding a new optional parameter, `properties`:

```swift
import DiscordBM
let bot = await BotGatewayManager(
    identifyPayload: .init(
        token: "DISCORD_TOKEN",
        properties: .init(browser: "Discord iOS"), /// `.init(os: , browser: , device: )`
        presence: .init(activities: [], status: .online, afk: false),
        intents: [.messageContent, .guildMessages /* .. other intents .. */]
    )
)
```

This allows us to do things like spoof being on mobile, which is purely cosmetic, but it's pretty funny, and popular existing libraries such as Discord.JS have this already

<div align="center">

![image](https://github.com/user-attachments/assets/a3772872-35c0-498b-bcba-af94a01f3bfd)

</div>